### PR TITLE
Apply ZSH nullglob more broadly

### DIFF
--- a/chnode
+++ b/chnode
@@ -80,11 +80,7 @@ chnode() {
 				[ -n "$ZSH_NAME" ] && setopt localoptions nullglob KSH_ARRAYS
 				if brewexec="$(command -v brew)"; then
 					if brewcellar="$(brew --cellar 2>/dev/null)"; then
-					{
-						search+=("${brewcellar}"/node) || true
-						search+=("${brewcellar}"/node[0-9]*) || true
-						search+=("${brewcellar}"/node@*) || true
-					} 2>/dev/null
+						search+=("${brewcellar}"/node[0-9@]*) 2>/dev/null || true
 					fi
 				fi
 

--- a/chnode
+++ b/chnode
@@ -77,18 +77,18 @@ chnode() {
 				search=(/opt/nodes ~/.nodes ~/.nodenv/versions /usr/local/n/versions ~/.nvm/versions/node)
 				local brewexec brewdir brewcellar
 				
+				[ -n "$ZSH_NAME" ] && setopt localoptions nullglob KSH_ARRAYS
 				if brewexec="$(command -v brew)"; then
 					if brewcellar="$(brew --cellar 2>/dev/null)"; then
-            {
-						  search+=("${brewcellar}"/node) || true
-              search+=("${brewcellar}"/node[0-9]*) || true
-              search+=("${brewcellar}"/node@*) || true
-            } 2>/dev/null
+					{
+						search+=("${brewcellar}"/node) || true
+						search+=("${brewcellar}"/node[0-9]*) || true
+						search+=("${brewcellar}"/node@*) || true
+					} 2>/dev/null
 					fi
 				fi
 
 				local dir nodes
-				[ -n "$ZSH_NAME" ] && setopt localoptions nullglob KSH_ARRAYS
 				for dir in "${search[@]}"; do
 					nodes=("$dir"/*)
 					[ -e "${nodes[0]}" ] && NODES+=(${nodes[@]})
@@ -101,7 +101,7 @@ chnode() {
 				for dir in "${NODES[@]}"; do
 					node="$(basename "$dir")"
 					echo "${node#node-}"
-        done
+				done
 				return
 				;;
 


### PR DESCRIPTION
Adding the homebrew search paths relies on globbing, and this fails in ZSH if the globs don't match anything.  There was already code to check for ZSH and set `nullglob` below.  I've just moved it up a bit higher to apply to the homebrew globs, as well.