### PR TITLE
Fix README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Chnode
 =========
 [![NPM version][npm-badge]](http://badge.fury.io/js/chnode)
+
 [npm-badge]: https://badge.fury.io/js/chnode.png
 
 Change between installed Node versions in your current shell with a simple


### PR DESCRIPTION
Github Markdown reference-style links seems to expect an empty line before reference definition. Not documented. This fix the layout of current Readme badge link. Current project/fork should create a new badge.